### PR TITLE
fix: group anomaly acl bug

### DIFF
--- a/ad_miner/sources/modules/users.py
+++ b/ad_miner/sources/modules/users.py
@@ -1436,7 +1436,11 @@ class Users:
     def genGroupAnomalyAcl(self, domain):
 
         if self.group_anomaly_acl is None:
-            return
+            page = Page(
+            self.arguments.cache_prefix, "group_anomaly_acl", "Group Anomaly ACL", "group_anomaly_acl"
+        )
+            page.render()
+            return 0
 
         formated_data_details = []
         formated_data = {}


### PR DESCRIPTION
When the number of ACL anomalies is zero, the `genGroupAnomalyAcl()` function didn't return anything, which causes an issue with the rating since `users.number_group_ACL_anomaly` is not defined, whereas it should be an integer. 
This fixes https://github.com/Mazars-Tech/AD_Miner/issues/34
It's also better to display an empty page rather than an error if there is no data.