### PR TITLE
fix: add failsaves for domains missing

### DIFF
--- a/ad_miner/sources/modules/domains.py
+++ b/ad_miner/sources/modules/domains.py
@@ -1579,7 +1579,10 @@ class Domains:
             ous_with_da_by_admin[domain[0]] = []
 
         for path in self.objects_to_ou_handlers:
-            self.paths_to_ou_handlers[path.nodes[-1].domain].append(path)
+            try:
+                self.paths_to_ou_handlers[path.nodes[-1].domain].append(path)
+            except KeyError:
+                self.paths_to_ou_handlers[path.nodes[-1].domain] = [path]
             if (
                 path.nodes[0].labels != "OU"
                 and path.nodes[0].name

--- a/ad_miner/sources/modules/neo4j_class.py
+++ b/ad_miner/sources/modules/neo4j_class.py
@@ -527,7 +527,7 @@ class Neo4j:
                 "nb_domain_collected": {
                     "name": "Count number of domains collected",
                     "request": "MATCH (m:Domain)-[r]->() "
-                    "RETURN distinct(m.domain)",
+                    "RETURN distinct(COALESCE(m.domain, m.name))",
                     "filename": "nb_domain_collected",
                     "method": self.requestList,
                 },


### PR DESCRIPTION
This adds two failsafe checks : 
 - Check that the domains are not None, if so returns the name of the domain
 - For the `generatePathToOUHandlers` method, check if the key for the domain exists. Should fix #25