### PR TITLE
Fix crash in level functionality

### DIFF
--- a/ad_miner/sources/modules/domains.py
+++ b/ad_miner/sources/modules/domains.py
@@ -1713,7 +1713,9 @@ class Domains:
         final_data = []
         for dico in self.vuln_functional_level:
             d = dico.copy()
-            if d['Level maturity'] <= 1:
+            if d['Level maturity'] is None:
+                continue
+            elif d['Level maturity'] <= 1:
                 color = "red"
             elif d['Level maturity'] <= 3:
                 color = "orange"


### PR DESCRIPTION
For some reason, the generation can crash when checking level functionality of the forest:

```
$ AD-miner -u neo4j -p Password -cf test
[-]Done in 29.59 s - 113471 objects
[+]Requests finished !
[+]Computing domains objects
[+]Generate paths to objects that can GPLink GPOs on OUs
[!] Warning : Add a description in description.json for the key '_paths_to_ou_handlers'.
[!] Warning : Add a description in description.json for the key '_paths_to_ou_handlers'.
[!] Warning : Add a description in description.json for the key '_paths_to_ou_handlers'.
[+]Split objects into types...
[+][Done]
[+]... from users
[+]... from computers
[+]... from groups
[+]... from OUs
[+]Generate paths to unconstrained delegations
[+]Doing domain DOMAINA.COM
[+]Doing domain DOMAINB.COM
[+]Doing domain DOMAINC.LOCAL
[+]Generating path to unconstrained 2nd phase ????
Traceback (most recent call last):
  File "/home/user/.local/bin/AD-miner", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/.local/pipx/venvs/ad-miner/lib/python3.11/site-packages/ad_miner/__main__.py", line 171, in main
    domains = Domains(arguments, neo4j)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/pipx/venvs/ad-miner/lib/python3.11/site-packages/ad_miner/sources/modules/domains.py", line 244, in __init__
    self.genInsufficientForestDomainsLevels()
  File "/home/user/.local/pipx/venvs/ad-miner/lib/python3.11/site-packages/ad_miner/sources/modules/domains.py", line 1717, in genInsufficientForestDomainsLevels
    if d['Level maturity'] <= 1:
       ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<=' not supported between instances of 'NoneType' and 'int'
```

This PR fix the crashes.