### PR TITLE
fix: fix non display for zero values on log scale

### DIFF
--- a/ad_miner/sources/html/templates/cards_modal_header.html
+++ b/ad_miner/sources/html/templates/cards_modal_header.html
@@ -71,6 +71,7 @@
             function changeScale() {
                 if (logScale) {
                     allCharts.forEach(chart => {
+                        chart.data.datasets[0].data = chart.data.datasets[0].data.map(value => value === 0.1 ? 0 : value);
                         chart.options.scales.y = {
                             type: 'linear'
                         };
@@ -80,8 +81,12 @@
                 }
                 else {
                     allCharts.forEach(chart => {
+                        chart.data.datasets[0].data = chart.data.datasets[0].data.map(value => value === 0 ? 0.1 : value);
                         chart.options.scales.y = {
-                            type: 'logarithmic'
+                            type: 'logarithmic',
+                            ticks: {
+                            callback: (value, index) => index === 0 ? '0' : value
+                            }
                         };
                         chart.update();
                     })

--- a/ad_miner/sources/html/templates/cards_modal_header.html
+++ b/ad_miner/sources/html/templates/cards_modal_header.html
@@ -68,6 +68,8 @@
             var allCharts = [];
             var logScale = false;
 
+            // Change the scaling from linear to log and vice-versa
+            // Because 0-values are not supported by log scale, it changes them to 0.1
             function changeScale() {
                 if (logScale) {
                     allCharts.forEach(chart => {
@@ -82,12 +84,30 @@
                 else {
                     allCharts.forEach(chart => {
                         chart.data.datasets[0].data = chart.data.datasets[0].data.map(value => value === 0 ? 0.1 : value);
-                        chart.options.scales.y = {
+                        if (chart.data.datasets[0].data.includes(0.1)) {
+                            chart.options.scales.y = {
                             type: 'logarithmic',
                             ticks: {
-                            callback: (value, index) => index === 0 ? '0' : value
+                                // We change the 0.1 value on the y-axis to 0
+                                callback: (value, index) => index === 0 ? '0' : value
+                                }
+                            };
+                            chart.options.plugins.tooltip = {
+                                // Hook to artificially change the displayed value of the tooltip to 0
+                                callbacks: {
+                                    label: function(context) {
+                                        let label = context.dataset.label;
+                                        let number = context.parsed.y;
+                                        return number === 0.1 ? label + ": " + "0" : label + ": " + number.toString();
+                                    }
+                                }
                             }
-                        };
+                        }
+                        else {
+                            chart.options.scales.y = {
+                            type: 'logarithmic'
+                            };
+                        }
                         chart.update();
                     })
                     logScale = true;


### PR DESCRIPTION
Small trick : when showing the log view, it replaces every 0 by 0.1 and then change the y-axis origin value to 0.