### PR TITLE
feat: update requests.json

### DIFF
--- a/ad_miner/sources/modules/requests.json
+++ b/ad_miner/sources/modules/requests.json
@@ -621,7 +621,7 @@
     },
     "vuln_functional_level": {
         "name": "Insufficient forest and domains functional levels. According to ANSSI (on a scale from 1 to 5, 5 being the better): the security level is at 1 if functional level (FL) <= Windows 2008 R2, at 3 if FL <= Windows 2012R2, at 4 if FL <= Windows 2016 / 2019 / 2022.",
-        "request": "MATCH (o:Domain) WHERE o.functionallevel IS NOT NULL RETURN CASE WHEN toUpper(o.functionallevel) CONTAINS \"2000\" OR toUpper(o.functionallevel) CONTAINS \"2003\" OR toUpper(o.functionallevel) CONTAINS \"2008\" OR toUpper(o.functionallevel) CONTAINS \"2008 R2\" THEN 1 WHEN toUpper(o.functionallevel) CONTAINS \"2012 R2\" THEN 2 WHEN toUpper(o.functionallevel) CONTAINS \"2016\" OR toUpper(o.functionallevel) CONTAINS \"2018\" OR toUpper(o.functionallevel) CONTAINS \"2020\" OR toUpper(o.functionallevel) CONTAINS \"2022\" THEN 5 END as `Level maturity`, o.distinguishedname as `Full name`, o.functionallevel as `Functional level`",
+        "request": "MATCH (o:Domain) WHERE NOT(o.functionallevel IS NULL OR SIZE(o.functionallevel) < 1) RETURN CASE WHEN toUpper(o.functionallevel) CONTAINS \"2000\" OR toUpper(o.functionallevel) CONTAINS \"2003\" OR toUpper(o.functionallevel) CONTAINS \"2008\" OR toUpper(o.functionallevel) CONTAINS \"2008 R2\" THEN 1 WHEN toUpper(o.functionallevel) CONTAINS \"2012 R2\" THEN 2 WHEN toUpper(o.functionallevel) CONTAINS \"2016\" OR toUpper(o.functionallevel) CONTAINS \"2018\" OR toUpper(o.functionallevel) CONTAINS \"2020\" OR toUpper(o.functionallevel) CONTAINS \"2022\" THEN 5 END as `Level maturity`, o.distinguishedname as `Full name`, o.functionallevel as `Functional level`",
         "output_type": "dict"
     },
     "vuln_sidhistory_dangerous": {


### PR DESCRIPTION
Modify query for domain functional level to address data coming from rusthound where an empty string is used instead of NULL. The where statement no longer checks against NULL but also against strings of size < 1