### PR TITLE
fix: pwdlastset attribute not set throws NoneType in rating

### DIFF
--- a/ad_miner/sources/modules/domains.py
+++ b/ad_miner/sources/modules/domains.py
@@ -76,13 +76,13 @@ class Domains:
             [
                 user
                 for user in self.users_pwd_not_changed_since
-                if user["days"] > neo4j.password_renewal
+                if user["days"] is None or user["days"] > neo4j.password_renewal # we need None > Unknown
             ]
             if self.users_pwd_not_changed_since is not None
             else None
         )
         self.users_pwd_not_changed_since_1y = (
-            [user for user in self.users_pwd_not_changed_since if user["days"] > 365]
+            [user for user in self.users_pwd_not_changed_since if user["days"] is None or user["days"] > 365]
             if self.users_pwd_not_changed_since is not None
             else None
         )

--- a/ad_miner/sources/modules/main_page.py
+++ b/ad_miner/sources/modules/main_page.py
@@ -223,7 +223,7 @@ def create_dico_data(
             domains.kud_list
         ) if domains.kud_list else 0,
         "users_constrained_delegations": len(computers.users_constrained_delegations) if computers.users_constrained_delegations else 0,
-        "krb_last_change": max([dict["pass_last_change"] for dict in users.users_krb_pwd_last_set], default=0),
+        "krb_last_change": max([dict["pass_last_change"] for dict in users.users_krb_pwd_last_set if dict["pass_last_change"] is not None], default=0),
         "users_admin_of_computers": len(users.users_admin_computer_count) if users.users_admin_computer_count else 0,
         "server_users_could_be_admin": users.servers_with_most_paths if users.servers_with_most_paths else 0,
         "dom_admin_on_non_dc": len(users.users_domain_admin_on_nondc) if users.users_domain_admin_on_nondc else 0,

--- a/ad_miner/sources/modules/rating.py
+++ b/ad_miner/sources/modules/rating.py
@@ -32,7 +32,7 @@ def rating(users, domains, computers, objects, azure, arguments):
     )
     d["on_premise"][
         time_since(
-            max([dict["pass_last_change"] for dict in users.users_krb_pwd_last_set], default=None),
+            max([dict["pass_last_change"] for dict in users.users_krb_pwd_last_set if dict["pass_last_change"] is not None ], default=None),
             age=1 * 365,
             criticity=2,
         )

--- a/ad_miner/sources/modules/users.py
+++ b/ad_miner/sources/modules/users.py
@@ -569,11 +569,13 @@ class Users:
                     sortClass = str(elem["days"]).zfill(
                         6
                     )  # used to make the sorting feature work with icons
+                    if elem["days"] is None:
+                        return "<i class='bi bi-calendar3'></i> Unknown"
                     return "<i class='bi bi-calendar3 %s'></i> %d days ago" % (
                         sortClass,
                         elem["days"],
                     )
-            return "<i class='bi bi-calendar3'></i> Very recently"
+            return "<i class='bi bi-calendar3'></i> Unknown"
 
         generateGraphPathToAdmin(self, domain)
 

--- a/ad_miner/sources/modules/utils.py
+++ b/ad_miner/sources/modules/utils.py
@@ -144,7 +144,9 @@ def days_format(nb_days: int) -> str:
     Returns the date in a nice format
     """
     sortClass = str(nb_days).zfill(6)
-    if nb_days is None or nb_days > 19000:
+    if nb_days is None:
+        return f"<i class='{sortClass} bi bi-x-circle' style='color: rgb(255, 89, 94);'></i> Unknown"
+    if nb_days > 19000:
         return f"<i class='{sortClass} bi bi-x-circle' style='color: rgb(255, 89, 94);'></i> Never"
     y = nb_days // 365
     m = (nb_days % 365) // 30


### PR DESCRIPTION
- If attribute pwdlastset is not set in neo4j, the user is still drafted in the requests
- Everywhere in the tables, its "Last Password Change" value will be "Unknown"

This is referencing issue 133 https://github.com/Mazars-Tech/AD_Miner/issues/133