### PR TITLE
fix: Fix hover cards, donuts charts and search of disabled controls

### DIFF
--- a/ad_miner/sources/html/templates/main_header.html
+++ b/ad_miner/sources/html/templates/main_header.html
@@ -1722,7 +1722,7 @@
           {
             label: 'Vulnerabilities',
             cutout: '60%',
-            data: '{{on_premise|main_graph_data}}',
+            data: `{{on_premise|main_graph_data}}`,
             backgroundColor: [
               'rgba(245, 75, 75, 0.9)',
               'rgba(245, 177, 75, 0.9)',
@@ -1765,7 +1765,7 @@
           {
             label: 'Vulnerabilities',
             cutout: '60%',
-            data: '{{on_premise|permissions_data}}',
+            data: `{{on_premise|permissions_data}}`,
             backgroundColor: [
               'rgba(245, 75, 75, 0.9)',
               'rgba(245, 177, 75, 0.9)',
@@ -1808,7 +1808,7 @@
           {
             label: 'Vulnerabilities',
             cutout: '60%',
-            data: '{{on_premise|passwords_data}}',
+            data: `{{on_premise|passwords_data}}`,
             backgroundColor: [
               'rgba(245, 75, 75, 0.9)',
               'rgba(245, 177, 75, 0.9)',
@@ -1851,7 +1851,7 @@
           {
             label: 'Vulnerabilities',
             cutout: '60%',
-            data: '{{on_premise|kerberos_data}}',
+            data: `{{on_premise|kerberos_data}}`,
             backgroundColor: [
               'rgba(245, 75, 75, 0.9)',
               'rgba(245, 177, 75, 0.9)',
@@ -1894,7 +1894,7 @@
           {
             label: 'Vulnerabilities',
             cutout: '60%',
-            data: '{{on_premise|misc_data}}',
+            data: `{{on_premise|misc_data}}`,
             backgroundColor: [
               'rgba(245, 75, 75, 0.9)',
               'rgba(245, 177, 75, 0.9)',
@@ -1981,7 +1981,7 @@
           {
             label: 'Vulnerabilities',
             cutout: '60%',
-            data: '{{azure|attack_path_data}}',
+            data: `{{azure|attack_path_data}}`,
             backgroundColor: [
               'rgba(245, 75, 75, 0.9)',
               'rgba(245, 177, 75, 0.9)',
@@ -2024,7 +2024,7 @@
           {
             label: 'Vulnerabilities',
             cutout: '60%',
-            data: '{{azure|ad_connect_data}}',
+            data: `{{azure|ad_connect_data}}`,
             backgroundColor: [
               'rgba(245, 75, 75, 0.9)',
               'rgba(245, 177, 75, 0.9)',
@@ -2067,7 +2067,7 @@
           {
             label: 'Vulnerabilities',
             cutout: '60%',
-            data: '{{azure|ms_graph_data}}',
+            data: `{{azure|ms_graph_data}}`,
             backgroundColor: [
               'rgba(245, 75, 75, 0.9)',
               'rgba(245, 177, 75, 0.9)',
@@ -2110,7 +2110,7 @@
           {
             label: 'Vulnerabilities',
             cutout: '60%',
-            data: '{{azure|sp_mi_data}}',
+            data: `{{azure|sp_mi_data}}`,
             backgroundColor: [
               'rgba(245, 75, 75, 0.9)',
               'rgba(245, 177, 75, 0.9)',

--- a/ad_miner/sources/js/main_circle.js
+++ b/ad_miner/sources/js/main_circle.js
@@ -161,8 +161,8 @@ function display_all_hexagons(dico_entry) {
   card_right.forEach((el) =>
     el.addEventListener('mouseover', (event) => {
       var div = document.querySelectorAll('.hexa-main-div');
-      div.forEach(e => e.querySelectorAll('h5').innerText = el.getAttribute('custom-title'));
-      div.forEach(e => e.querySelectorAll('p').innerHTML = el.getAttribute('custom-status'));
+      div.forEach(e => e.querySelector('h5').innerText = el.getAttribute('custom-title'));
+      div.forEach(e => e.querySelector('p').innerHTML = el.getAttribute('custom-status'));
       div.forEach(e => e.style.opacity = 1);
     }),
   );

--- a/ad_miner/sources/js/search_bar.js
+++ b/ad_miner/sources/js/search_bar.js
@@ -39,7 +39,8 @@ function updateDropdown(filteredControls) {
         "red": '<i class="bi bi-exclamation-diamond-fill search-element-icon" style="color: rgb(245, 75, 75);"></i>',
         "orange": '<i class="bi bi-exclamation-triangle-fill search-element-icon" style="color: rgb(245, 177, 75);"></i>',
         "yellow": '<i class="bi bi-dash-circle-fill search-element-icon" style="color: rgb(255, 221, 0);"></i>',
-        "green": '<i class="bi bi-check-circle-fill search-element-icon" style="color: rgb(91, 180, 32);"></i>'
+        "green": '<i class="bi bi-check-circle-fill search-element-icon" style="color: rgb(91, 180, 32);"></i>',
+        "grey": '<i class="bi bi-dash-circle-fill search-element-icon" style="color: rgb(133,135,150);"></i>'
     };
     filteredControls.forEach(control => {
         const dropdownItem = document.createElement("a");


### PR DESCRIPTION
Fixes three bugs :
 - Bug when hovering right side cards on main page that would not display the correct text
 - Bug with the genration of donut charts on the indicator of exposure breakdown
 - Missing icon in searchbar for controls with grey rating