### PR TITLE
feat: check and verify Neo4j version

### DIFF
--- a/ad_miner/__main__.py
+++ b/ad_miner/__main__.py
@@ -146,7 +146,14 @@ def main() -> None:
 
     prepare_render(arguments)
 
-    extract_date, total_objects, number_relations, boolean_azure = pre_request(arguments)
+    neo4j_version, extract_date, total_objects, number_relations, boolean_azure = pre_request(arguments)
+
+    version = neo4j_version.get('version')
+    logger.print_success("You are using Neo4J " + version + "")
+
+    if not version.startswith('4.4.'):
+        logger.print_error("You must install Neo4J 4.4.X in order to fully use AD Miner")
+        sys.exit(-1)
 
     number_objects = sum([type_label["number_type"] for type_label in total_objects])
 


### PR DESCRIPTION
New check before running AD Miner in order to avoid using versions that are not compliant with some of the cypher queries.