### PR TITLE
fix: Fix table acl anomaly

### DIFF
--- a/ad_miner/sources/modules/description.json
+++ b/ad_miner/sources/modules/description.json
@@ -504,7 +504,7 @@
     "poa": "Ensure that this list is empty by setting the ms-DS-User-Password-Not-Required attribute to false for every user."
   },
   "anomaly_acl": {
-    "title": "Anomaly ACL",
+    "title": "ACL Anomalies",
     "description": "An ACL (Access Control List) is a security mechanism that defines permissions and access rights for objects within the Active Directory structure.",
     "risk": "Misconfigured ACL can create access points or privilege escalation that an attacker could use to compromise the domain.<br /><br /><i class='bi bi-star-fill'></i><i class='bi bi-star-fill'></i><i class='bi bi-star-fill'></i> : At least one domain admin as target<br /><i class='bi bi-star-fill'></i><i class='bi bi-star-fill'></i><i class='bi bi-star'></i> : At least one object has a path to domain admin<br /><i class='bi bi-star-fill'></i><i class='bi bi-star'></i><i class='bi bi-star'></i> : At least one object admin of a computer<br /><i class='bi bi-star'></i><i class='bi bi-star'></i><i class='bi bi-star'></i> : Other",
     "poa": "Regularly review and clean up ACL entries for users and groups that no longer require them."

--- a/ad_miner/sources/modules/main_page.py
+++ b/ad_miner/sources/modules/main_page.py
@@ -410,7 +410,7 @@ def render(
         "dangerous_paths": f"More than {domains.total_dangerous_paths} dangerous paths to DA",
         "users_password_not_required": f"{dico_data['value']['users_password_not_required']} users can bypass your password policy",
         "can_read_laps": f"{len(users.can_read_laps_parsed)} accounts can read LAPS passwords",
-        "anomaly_acl": f"{users.number_group_ACL_anomaly} groups with potential ACL anomalies",
+        "anomaly_acl": f"{users.number_group_ACL_anomaly} objects with potential ACL anomalies",
         "empty_groups": f"{len(domains.empty_groups)} groups without any member",
         "empty_ous": f"{len(domains.empty_ous)} OUs without any member",
         "has_sid_history": f"{len(users.has_sid_history)} objects can exploit SID History",

--- a/ad_miner/sources/modules/users.py
+++ b/ad_miner/sources/modules/users.py
@@ -1512,9 +1512,10 @@ class Users:
 
         for k in range(len(self.anomaly_acl)):
 
-            label = generic_formating.clean_label(self.anomaly_acl[k]['LABELS(g)'])
+            label = generic_formating.clean_label(self.anomaly_acl[k]['type(r2)'])
 
-            name_label_instance = f"{self.anomaly_acl[k]['g.name']}{label}"
+            name_label_instance = f"{self.anomaly_acl[k]['g.name']}{label}{target}"
+
 
             if formated_data.get(name_label_instance) and formated_data[name_label_instance]["type"] == self.anomaly_acl[k]["type(r2)"] and formated_data[name_label_instance]["label"] == label:
                 formated_data[name_label_instance]["targets"].append(self.anomaly_acl[k]["n.name"])


### PR DESCRIPTION
- Remove typo in control's title and description
- Fix table to display every ACL for each object with different set of target