### PR TITLE
ops: add Dockerfile and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+# Set the working directory in the container
+WORKDIR /tmp
+
+# Install necessary system dependencies for Git
+RUN apt-get update && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install AD-Miner from the Git repository
+RUN pip install --no-cache-dir 'git+https://github.com/Mazars-Tech/AD_Miner.git'

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ ADMiner is also available on some Linux distributions:
 - BlackArch: `pacman -S ad-miner`
 - NixOS: `nix-env -iA nixos.ad-miner`
 
+A Docker image is available to build. Build the image with the following commmand:
+
+```sh
+docker build -t ad-miner .
+```
+
+To run this with the BloodHound Community Edition data, use the commands below:
+
+```sh
+docker run -v ${PWD}:/tmp ad-miner AD-miner -b bolt://host.docker.internal:7687 -u neo4j -p bloodhoundcommunityedition -cf docker-test
+```
+
+Note that mounting the volume with `-v` is critical to get the output of the data. This assumes that the BHCE server is running on the Docker host with default settings. 
+
 ## Usage ##
 
 Run the tool:


### PR DESCRIPTION
This PR adds a Dockerfile to build a Docker image to run this tool. This is useful in an environment where there may not be direct Internet access, as the Docker image can be exported. 