### PR TITLE
Restrict cache pickle deserialization

### DIFF
--- a/ad_miner/scripts/analyse_cache.py
+++ b/ad_miner/scripts/analyse_cache.py
@@ -1,6 +1,11 @@
-import pickle
 import sys
 from pathlib import Path
+
+try:
+    from ad_miner.sources.modules.cache_security import load_cache_entry
+except ModuleNotFoundError:
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from ad_miner.sources.modules.cache_security import load_cache_entry
 
 # Constants
 MODULES_DIRECTORY = Path(__file__).parent / 'sources/modules'
@@ -13,7 +18,7 @@ def request_a():
 
 def retrieveCacheEntry(full_module_path: Path):
     with open(full_module_path, "rb") as f:
-        return pickle.load(f)
+        return load_cache_entry(f)
 
 
 list_path = request_a()

--- a/ad_miner/sources/modules/cache_class.py
+++ b/ad_miner/sources/modules/cache_class.py
@@ -2,6 +2,8 @@ import os
 import pickle
 import csv
 
+from ad_miner.sources.modules.cache_security import load_cache_entry
+
 
 class Cache:
     def __init__(self, arguments):
@@ -25,7 +27,7 @@ class Cache:
         full_name = self.cache_prefix + "_" + filename
         if os.path.exists(full_name):
             with open(full_name, "rb") as f:
-                return pickle.load(f)
+                return load_cache_entry(f)
         return False
 
     def createCsvFileFromRequest(self, filename, data, object_type):

--- a/ad_miner/sources/modules/cache_security.py
+++ b/ad_miner/sources/modules/cache_security.py
@@ -1,0 +1,24 @@
+import pickle
+
+
+class RestrictedCacheUnpickler(pickle.Unpickler):
+    ALLOWED_GLOBALS = {
+        ("ad_miner.sources.modules.graph_class", "Graph"),
+        ("ad_miner.sources.modules.node_neo4j", "Node"),
+        ("ad_miner.sources.modules.path_neo4j", "Path"),
+        ("builtins", "dict"),
+        ("builtins", "frozenset"),
+        ("builtins", "list"),
+        ("builtins", "set"),
+        ("builtins", "slice"),
+        ("builtins", "tuple"),
+    }
+
+    def find_class(self, module, name):
+        if (module, name) in self.ALLOWED_GLOBALS:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(f"Unsupported cache object: {module}.{name}")
+
+
+def load_cache_entry(file_obj):
+    return RestrictedCacheUnpickler(file_obj).load()


### PR DESCRIPTION
## Summary
- add a restricted cache unpickler that only allows AD Miner cache model classes and basic containers
- route cache loading in both the main cache class and analyse_cache.py through the restricted loader
- preserve direct execution of analyse_cache.py by adding an import fallback for local script execution

Fixes #238

## Verification
- python -m compileall ad_miner/scripts/analyse_cache.py ad_miner/sources/modules/cache_class.py ad_miner/sources/modules/cache_security.py
- malicious pickle PoC is rejected with Unsupported cache object: builtins.eval and does not create the marker file
- legitimate AD Miner Node/Path cache object still loads through the restricted loader